### PR TITLE
fix: correct controller method name

### DIFF
--- a/src/main/java/com/products/SpringBootWithMySql/controller/CourseController.java
+++ b/src/main/java/com/products/SpringBootWithMySql/controller/CourseController.java
@@ -18,7 +18,7 @@ public class CourseController {
     CourseService courseService;
 
     @PostMapping("/course")
-    public ResponseEntity<String> creteCourse(@RequestBody Course course) {
+    public ResponseEntity<String> createCourse(@RequestBody Course course) {
         var status = courseService.upsert(course);
         return new ResponseEntity<>(status, HttpStatus.CREATED);
     }


### PR DESCRIPTION
## Summary
- rename `creteCourse` controller method to `createCourse`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b69528ba54832ba48cca539aa5c72b